### PR TITLE
 Don't throw if a file is on the search path

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,6 @@
 import test from "ava";
 import { safeWhich, isWindows } from "./index";
+import * as os from "os";
 import * as path from "path";
 
 const originalEnv = process.env;
@@ -68,6 +69,11 @@ if (isWindows) {
 else {
 	test("program is found if on path and executable", async (t) => {
 		process.env.PATH = path.join(testResources, "path");
+		t.deepEqual(await safeWhich("program"), path.join(testResources, "path", "program"));
+	});
+
+	test("does not throw if a non-directory file is on the search path", async (t) => {
+		process.env.PATH = path.join(testResources, "path/program") + path.delimiter + path.join(testResources, "path");
 		t.deepEqual(await safeWhich("program"), path.join(testResources, "path", "program"));
 	});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,9 +29,17 @@ export async function safeWhich(program: string): Promise<string> {
 				return completePath;
 			}
 			catch (err) {
-				if (err.code !== "ENOENT") {
-					throw err;
+				if (typeof err === "object" && err !== null && 'code' in err) {
+					if (err.code === "ENOTDIR") {
+						console.warn(`While resolving program ${program}, skipping ${searchPath} ` + 
+							"because it is not a directory.");
+						break;
+					}
+					if (err.code === "ENOENT") {
+						continue;
+					}
 				}
+				throw err;
 			}
 		}
 	}


### PR DESCRIPTION
In the unusual case that a file that isn't a directory is on the search path, log a warning rather than throwing.